### PR TITLE
add API 'getpost'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/.idea/

--- a/app/controllers/muscle_posts_controller.rb
+++ b/app/controllers/muscle_posts_controller.rb
@@ -11,18 +11,52 @@ class MusclePostsController < ApplicationController
     # データを取得
     result = MusclePost.where(id: muscle_post_id_ary)
                  .joins(tag_maps: :body_part)
-                 .select("muscle_posts.*, body_parts.name")
                  .joins(:user)
                  .select("users.icon, users.identity, users.name, muscle_posts.*, body_parts.name")
 
     # 整形
+    temp_hash = data_formation(result)
+    responses = []
+    for muscle_post_id in muscle_post_id_ary
+      responses.push(temp_hash[muscle_post_id])
+    end
+
+    # レスポンスを返す
+    render :json => responses.to_json
+  end
+
+  def getpost
+    # 要求数取得
+    muscle_post_id = params[:id]
+
+    # データを取得
+    result = MusclePost.where(id: muscle_post_id)
+                 .joins(tag_maps: :body_part)
+                 .joins(:user).select("users.icon, users.identity, users.name, muscle_posts.*, body_parts.name")
+
+    # データ存在しないとき、[]を返す
+    if result.blank?
+      render :json => []
+      return
+    end
+
+    # 整形
+    temp_hash = data_formation(result)
+    responses = [temp_hash[muscle_post_id.to_i]]
+
+    # レスポンスを返す
+    render :json => responses.to_json
+  end
+
+  private
+  # 整形
+  def data_formation(result)
     temp_hash = {}
     for r in result
-     if temp_hash.has_key?(r.id)
+      if temp_hash.has_key?(r.id)
         temp_hash[r.id]['body_parts'].push(r.name)
         next
       end
-      temp_hash[r.id] = {}
       temp_hash[r.id] = {}
       temp_hash[r.id]['icon'] = r.icon
       temp_hash[r.id]['identity'] = r.identity
@@ -31,13 +65,6 @@ class MusclePostsController < ApplicationController
       temp_hash[r.id]['body'] = r.body
       temp_hash[r.id]['body_parts'] = [r.name]
     end
-
-    responses = []
-    for muscle_post_id in muscle_post_id_ary
-      responses.push(temp_hash[muscle_post_id])
-    end
-
-    # レスポンスを返す
-    render :json => responses.to_json
+    temp_hash
   end
 end

--- a/app/controllers/muscle_posts_controller.rb
+++ b/app/controllers/muscle_posts_controller.rb
@@ -15,7 +15,7 @@ class MusclePostsController < ApplicationController
                  .select("users.icon, users.identity, users.name, muscle_posts.*, body_parts.name")
 
     # 整形
-    temp_hash = data_formation(result)
+    temp_hash = muscle_post_data_formation(result)
     responses = []
     for muscle_post_id in muscle_post_id_ary
       responses.push(temp_hash[muscle_post_id])
@@ -25,8 +25,8 @@ class MusclePostsController < ApplicationController
     render :json => responses.to_json
   end
 
-  def getpost
-    # 要求数取得
+  def get_muscle_post
+    # id取得
     muscle_post_id = params[:id]
 
     # データを取得
@@ -36,12 +36,12 @@ class MusclePostsController < ApplicationController
 
     # データ存在しないとき、[]を返す
     if result.blank?
-      render :json => []
+      render :json => [], :status => 404
       return
     end
 
     # 整形
-    temp_hash = data_formation(result)
+    temp_hash = muscle_post_data_formation(result)
     responses = [temp_hash[muscle_post_id.to_i]]
 
     # レスポンスを返す
@@ -50,7 +50,7 @@ class MusclePostsController < ApplicationController
 
   private
   # 整形
-  def data_formation(result)
+  def muscle_post_data_formation(result)
     temp_hash = {}
     for r in result
       if temp_hash.has_key?(r.id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/muscle_posts', to: "muscle_posts#timeline"
-  get '/muscle_posts/:id', to: "muscle_posts#getpost"
+  get '/muscle_posts/:id', to: "muscle_posts#get_muscle_post"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/muscle_posts', to: "muscle_posts#timeline"
+  get '/muscle_posts/:id', to: "muscle_posts#getpost"
 end


### PR DESCRIPTION
idで投稿を取得API
MasclePostsControllerに `getpost`のアクションを作成
`timeline`と`getpost`に共通部分があるため、`data_formation`といった共通部分を抽出
